### PR TITLE
1. Clarify the definition of the effective pulse length.

### DIFF
--- a/docs/crr341.adoc
+++ b/docs/crr341.adoc
@@ -331,7 +331,7 @@ S_{v} = 10\log_{10}(P_{r}) + 20\log_{10}(r) + 2\alpha r - 10\log_{10}\left(\frac
 \end{equation}
 ++++
 
-where latexmath:[\psi] is the equivalent beam angle (equivalent_beam_angle, sr), latexmath:[\tau_e] is the effective pulse duration (transmit_duration_equivalent, s), and _G_ is the transducer gain (transducer_gain, dB).
+where latexmath:[\psi] is the equivalent beam angle (equivalent_beam_angle, sr), latexmath:[\tau_e] is the effective pulse duration (_receive_duration_effective, s), and _G_ is the transducer gain (transducer_gain, dB).
 
 === Type 2
 
@@ -357,7 +357,7 @@ S_v = 20\log_{10}\left(\frac{A}{\sqrt{2}}\right) + 20\log_{10}(r) + 2\alpha r - 
 \end{equation}
 ++++
 
-where _c_ is sound speed (sound_speed_indicative, m/s), latexmath:[\tau_e] is the effective pulse duration (transmit_duration_equivalent, s), and latexmath:[\Psi] is the equivalent beam angle (equivalent_beam_angle, sr). Considering the time-varied-gain (TVG) effect on the echo shape cite:[sawada1993], the replacement of _r_ by latexmath:[r - r_0], where latexmath:[r_0 = \frac{1}{4} c \tau_e], is recommended cite:[maclennan1986,furusawaRangeErrorsSound1999] for calculation of latexmath:[S_v].
+where _c_ is sound speed (sound_speed_indicative, m/s), latexmath:[\tau_e] is the effective pulse duration (_receive_duration_effective, s), and latexmath:[\Psi] is the equivalent beam angle (equivalent_beam_angle, sr). Considering the time-varied-gain (TVG) effect on the echo shape cite:[sawada1993], the replacement of _r_ by latexmath:[r - r_0], where latexmath:[r_0 = \frac{1}{4} c \tau_e], is recommended cite:[maclennan1986,furusawaRangeErrorsSound1999] for calculation of latexmath:[S_v].
 
 === Type 3
 
@@ -384,11 +384,20 @@ where latexmath:[r] is the range from the transducer to the target [m], latexmat
 [stem]
 ++++
 \begin{equation}
-S_v = P_r + 20\log_{10}(r) + 2\alpha r - 10\log_{10}\left(\frac{P_t \lambda^2 c \psi \tau}{32 \pi^2} \right) - 2G_0 - 2S_{a,corr},
+S_v = P_r + 20\log_{10}(r) + 2\alpha r - 10\log_{10}\left(\frac{P_t \lambda^2 c \psi \tau_e}{32 \pi^2} \right) - 2G_0,
 \end{equation}
 ++++
 
-where latexmath:[c] is sound speed [m s^-1^], latexmath:[\psi] the equivalent beam angle (variable _equivalent_beam_angle_), latexmath:[\tau] the pulse duration (variable _transmit_duration_nominal_), and latexmath:[S_{a,corr}] a correction term (variable _sa_correction_).
+where latexmath:[c] is sound speed [m s^-1^], latexmath:[\psi] the equivalent beam angle (variable _equivalent_beam_angle_), latexmath:[\tau_e] the effective pulse duration (variable _receive_duration_effective_).
+
+The effective pulse duration is computed for EK60, ES60 and ES70 from the nominal transmit pulse duration (variable _transmit_duration_nominal_) and the Simrad term latexmath:[S_{a,corr}] from the calibration exercise as :
+
+[stem]
+++++
+\begin{equation}
+\tau_e = \tau + 2S_{a,corr},
+\end{equation}
+++++
 
 The range from the transducer to the target is given by:
 

--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -141,11 +141,7 @@ e|Variables | |
  |{var}float sample_time_offset(ping_time, tx_beam) |M |Time offset applied to sample time-stamps and intended for applying a range correction (e.g. as caused by signal processing delays). Positive values reduce the calculated range to a sample. The range of a given sample at index sample_index and if a constant sound speed is applied is given by range= sound_speed_at_transducer*(blanking_interval+sample_index*sample_interval - sample_time_offset)/2
  3+|{attr}:long_name = "Time offset that is subtracted from the timestamp of each sample" 
  3+|{attr}:units = "s" 
- 
- |{var}float sa_correction(ping_time, tx_beam) |MA | XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
- 3+|{attr}:long_name = "" 
- 3+|{attr}:units = "" 
- 
+
  |{var}float blanking_interval(ping_time, beam) |M |Amount of time during reception where samples are discarded. The number of discarded sample is given by blanking_interval*sample_interval.
  3+|{attr}:long_name = "Amount of time during reception where samples are discarded" 
  3+|{attr}:units = "s" 
@@ -164,17 +160,17 @@ e|Variables | |
  3+|{attr}:long_name = "Nominal bandwidth of transmitted pulse" 
  3+|{attr}:units = "Hz" 
  3+|{attr}float :valid_min = 0.0 
- 
- |{var}float transmit_duration_equivalent(ping_time, tx_beam) |MA |Equivalent duration of the transmit pulse. This is the square pulse containing the same energy as the actual transmitted pulse. Necessary for both type 1 and 2 conversion equations.
- 3+|{attr}:long_name = "Equivalent duration of transmitted pulse" 
+
+ |{var}float transmit_duration_nominal(ping_time, tx_beam) |M |Nominal duration of the transmit pulse. This is not the effective pulse duration.
+ 3+|{attr}:long_name = "Nominal duration of transmitted pulse"
+ 3+|{attr}:units = "s"
+ 3+|{attr}float :valid_min = 0.0
+
+ |{var}float receive_duration_effective(ping_time, tx_beam) |MA |Effective duration of the receive pulse. This is the duration of the square pulse containing the same energy as the actual receive pulse. This parameter is either theoretical or comes from a calibration exercise and adjusts the nominal duration of the transmitted pulse to the measured one. During calibration it is obtained by integrating the energy of the received signal on the calibration target normalised by its maximum energy. Necessary for type 1, 2,3 and 4 conversion equations.
+ 3+|{attr}:long_name = "Effective duration of transmitted pulse"
  3+|{attr}:units = "s" 
- 3+|{attr}float :valid_min = 0.0 
- 
- |{var}float transmit_duration_nominal(ping_time, tx_beam) |M |Nominal duration of the transmit pulse. This is not the equivalent pulse duration.
- 3+|{attr}:long_name = "Nominal duration of transmitted pulse" 
- 3+|{attr}:units = "s" 
- 3+|{attr}float :valid_min = 0.0 
- 
+ 3+|{attr}float :valid_min = 0.0
+
  |{var}float transmit_frequency_start(ping_time, tx_beam) |M |Frequency at the start of the transmit pulse. The beam dimension can be omitted, in which case the value apples to all beams in the ping.
  3+|{attr}:long_name = "Start frequency in transmitted pulse" 
  3+|{attr}:standard_name = "sound_frequency" 


### PR DESCRIPTION
1. Clarify the definition of the effective pulse length.
2. Suppress the Sacorr parameter which is Simrad specific and has recently lead to confusion with EK80 (difference between Sacorr and Sacorr_adjust)
3. Modify equation type 3 for Sv calculation