### PR TITLE
Correction of calculation of effective pulse length for equation 3

### DIFF
--- a/docs/crr341.adoc
+++ b/docs/crr341.adoc
@@ -390,12 +390,12 @@ S_v = P_r + 20\log_{10}(r) + 2\alpha r - 10\log_{10}\left(\frac{P_t \lambda^2 c 
 
 where latexmath:[c] is sound speed [m s^-1^], latexmath:[\psi] the equivalent beam angle (variable _equivalent_beam_angle_), and latexmath:[\tau_e] the effective pulse duration (variable _receive_duration_effective_).
 
-The effective pulse duration is computed for EK60, ES60 and ES70 from the nominal transmit pulse duration (variable _transmit_duration_nominal_) and the Simrad term latexmath:[S_{a,corr}] from the calibration exercise as :
+The effective pulse duration is computed for EK60, ES60 and ES70 from the nominal transmit pulse duration (variable _transmit_duration_nominal_) and the Simrad term latexmath:[S_{a,corr}] in dB from the calibration exercise as :
 
 [stem]
 ++++
 \begin{equation}
-\tau_e = \tau + 2S_{a,corr},
+\tau_e = \tau * 10^{\frac{2S_{a,corr}}{10}},
 \end{equation}
 ++++
 

--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -166,8 +166,8 @@ e|Variables | |
  3+|{attr}:units = "s"
  3+|{attr}float :valid_min = 0.0
 
- |{var}float receive_duration_effective(ping_time, tx_beam) |MA |Effective duration of the receive pulse. This is the duration of the square pulse containing the same energy as the actual receive pulse. This parameter is either theoretical or comes from a calibration exercise and adjusts the nominal duration of the transmitted pulse to the measured one. During calibration it is obtained by integrating the energy of the received signal on the calibration target normalised by its maximum energy. Necessary for type 1, 2,3 and 4 conversion equations.
- 3+|{attr}:long_name = "Effective duration of transmitted pulse"
+ |{var}float receive_duration_effective(ping_time, tx_beam) |MA |Effective duration of the received pulse. This is the duration of the square pulse containing the same energy as the actual receive pulse. This parameter is either theoretical or comes from a calibration exercise and adjusts the nominal duration of the transmitted pulse to the measured one. During calibration it is obtained by integrating the energy of the received signal on the calibration target normalised by its maximum energy. Necessary for type 1, 2,3 and 4 conversion equations.
+ 3+|{attr}:long_name = "Effective duration of received pulse"
  3+|{attr}:units = "s" 
  3+|{attr}float :valid_min = 0.0
 


### PR DESCRIPTION
Correction of calculation of effective pulse length from nominal pulse length and Sa_correction in dB for equation type 3