### PR TITLE
Adding detected_bottom_range in BeamGroup

### DIFF
--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -145,34 +145,34 @@ e|Variables | |
  |{var}float blanking_interval(ping_time, beam) |M |Amount of time during reception where samples are discarded. The number of discarded sample is given by blanking_interval*sample_interval.
  3+|{attr}:long_name = "Amount of time during reception where samples are discarded" 
  3+|{attr}:units = "s" 
- 3+|{attr}:valid_min = "0.0"
-
+ 3+|{attr}:valid_min = "0.0" 
+ 
  |{var}float detected_bottom_range(ping_time, beam) |0 |Range from the transducer face where the bottom detection criteria were encountered for the amplitude or the phase of the backscattered echoes. The range of the bottom at index bottom_index with a monostatic transducer and if a constant sound speed is applied is given by detected_bottom_range= sound_speed_at_transducer*(blanking_interval+bottom_index*sample_interval - sample_time_offset)/2.
- 3+|{attr}:long_name = "Detected range of the bottom"
- 3+|{attr}:units = "m"
- 3+|{attr}:valid_min = "0.0"
-
+ 3+|{attr}:long_name = "Detected range of the bottom" 
+ 3+|{attr}:units = "m" 
+ 3+|{attr}:valid_min = "0.0" 
+ 
  |{var}sample_t time_varied_gain(ping_time) |MA |Time-varied gain (TVG) used for each ping. Should contain TVG coefficient vectors. Necessary for type 2 conversion equations.
- 3+|{attr}:long_name = "Time-varied-gain coefficients"
- 3+|{attr}:units = "dB"
- 3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude"
-
+ 3+|{attr}:long_name = "Time-varied-gain coefficients" 
+ 3+|{attr}:units = "dB" 
+ 3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude" 
+ 
  |{var}float transducer_gain(ping_time, beam) |MA |Gain of the transducer beam. This is the parameter that is set from a calibration exercise. Necessary for conversion equation type 1.
- 3+|{attr}:long_name = "Gain of transducer"
- 3+|{attr}:units = "dB"
-
+ 3+|{attr}:long_name = "Gain of transducer" 
+ 3+|{attr}:units = "dB" 
+ 
  |{var}float transmit_bandwidth(ping_time, tx_beam) |O |Estimated bandwidth of the transmitted pulse. For CW pulses, this is a function of the pulse duration and frequency. For FM pulses, this will be close to the difference between transmit_frequency_start and transmit_frequency_stop.
- 3+|{attr}:long_name = "Nominal bandwidth of transmitted pulse"
- 3+|{attr}:units = "Hz"
- 3+|{attr}float :valid_min = 0.0
-
+ 3+|{attr}:long_name = "Nominal bandwidth of transmitted pulse" 
+ 3+|{attr}:units = "Hz" 
+ 3+|{attr}float :valid_min = 0.0 
+ 
  |{var}float transmit_duration_nominal(ping_time, tx_beam) |M |Nominal duration of the transmit pulse. This is not the effective pulse duration.
- 3+|{attr}:long_name = "Nominal duration of transmitted pulse"
- 3+|{attr}:units = "s"
- 3+|{attr}float :valid_min = 0.0
-
+ 3+|{attr}:long_name = "Nominal duration of transmitted pulse" 
+ 3+|{attr}:units = "s" 
+ 3+|{attr}float :valid_min = 0.0 
+ 
  |{var}float receive_duration_effective(ping_time, tx_beam) |MA |Effective duration of the received pulse. This is the duration of the square pulse containing the same energy as the actual receive pulse. This parameter is either theoretical or comes from a calibration exercise and adjusts the nominal duration of the transmitted pulse to the measured one. During calibration it is obtained by integrating the energy of the received signal on the calibration target normalised by its maximum energy. Necessary for type 1, 2,3 and 4 conversion equations.
- 3+|{attr}:long_name = "Effective duration of received pulse"
+ 3+|{attr}:long_name = "Effective duration of received pulse" 
  3+|{attr}:units = "s" 
  3+|{attr}float :valid_min = 0.0 
  

--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -145,29 +145,34 @@ e|Variables | |
  |{var}float blanking_interval(ping_time, beam) |M |Amount of time during reception where samples are discarded. The number of discarded sample is given by blanking_interval*sample_interval.
  3+|{attr}:long_name = "Amount of time during reception where samples are discarded" 
  3+|{attr}:units = "s" 
- 3+|{attr}:valid_min = "0.0" 
- 
+ 3+|{attr}:valid_min = "0.0"
+
+ |{var}float detected_bottom_range(ping_time, beam) |0 |Range from the transducer face where the bottom detection criteria were encountered for the amplitude or the phase of the backscattered echoes. The range of the bottom at index bottom_index with a monostatic transducer and if a constant sound speed is applied is given by detected_bottom_range= sound_speed_at_transducer*(blanking_interval+bottom_index*sample_interval - sample_time_offset)/2.
+ 3+|{attr}:long_name = "Detected range of the bottom"
+ 3+|{attr}:units = "m"
+ 3+|{attr}:valid_min = "0.0"
+
  |{var}sample_t time_varied_gain(ping_time) |MA |Time-varied gain (TVG) used for each ping. Should contain TVG coefficient vectors. Necessary for type 2 conversion equations.
- 3+|{attr}:long_name = "Time-varied-gain coefficients" 
- 3+|{attr}:units = "dB" 
- 3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude" 
- 
+ 3+|{attr}:long_name = "Time-varied-gain coefficients"
+ 3+|{attr}:units = "dB"
+ 3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude"
+
  |{var}float transducer_gain(ping_time, beam) |MA |Gain of the transducer beam. This is the parameter that is set from a calibration exercise. Necessary for conversion equation type 1.
- 3+|{attr}:long_name = "Gain of transducer" 
- 3+|{attr}:units = "dB" 
- 
+ 3+|{attr}:long_name = "Gain of transducer"
+ 3+|{attr}:units = "dB"
+
  |{var}float transmit_bandwidth(ping_time, tx_beam) |O |Estimated bandwidth of the transmitted pulse. For CW pulses, this is a function of the pulse duration and frequency. For FM pulses, this will be close to the difference between transmit_frequency_start and transmit_frequency_stop.
- 3+|{attr}:long_name = "Nominal bandwidth of transmitted pulse" 
- 3+|{attr}:units = "Hz" 
- 3+|{attr}float :valid_min = 0.0 
- 
+ 3+|{attr}:long_name = "Nominal bandwidth of transmitted pulse"
+ 3+|{attr}:units = "Hz"
+ 3+|{attr}float :valid_min = 0.0
+
  |{var}float transmit_duration_nominal(ping_time, tx_beam) |M |Nominal duration of the transmit pulse. This is not the effective pulse duration.
- 3+|{attr}:long_name = "Nominal duration of transmitted pulse" 
- 3+|{attr}:units = "s" 
- 3+|{attr}float :valid_min = 0.0 
- 
+ 3+|{attr}:long_name = "Nominal duration of transmitted pulse"
+ 3+|{attr}:units = "s"
+ 3+|{attr}float :valid_min = 0.0
+
  |{var}float receive_duration_effective(ping_time, tx_beam) |MA |Effective duration of the received pulse. This is the duration of the square pulse containing the same energy as the actual receive pulse. This parameter is either theoretical or comes from a calibration exercise and adjusts the nominal duration of the transmitted pulse to the measured one. During calibration it is obtained by integrating the energy of the received signal on the calibration target normalised by its maximum energy. Necessary for type 1, 2,3 and 4 conversion equations.
- 3+|{attr}:long_name = "Effective duration of received pulse" 
+ 3+|{attr}:long_name = "Effective duration of received pulse"
  3+|{attr}:units = "s" 
  3+|{attr}float :valid_min = 0.0 
  


### PR DESCRIPTION
The simple case for monostatic transducer with constant sound speed is detailed.