### PR TITLE
Fix ADCP doc

### DIFF
--- a/docs/tableADCP_sub_group.adoc
+++ b/docs/tableADCP_sub_group.adoc
@@ -4,7 +4,6 @@
 |===
 |Description |Obligation |Comment
 e|Types | |
- 2+|{var}ping_time(*) ping_t |Variable length vector used to store ping time of pings used in averaging. Type added for ADCP.
  2+|{var}float(*) sample_v |Variable length vector used to store ragged arrays of velocity data. Type added for ADCP.
 
 e|Variables | |

--- a/docs/tableADCP_sub_group.adoc
+++ b/docs/tableADCP_sub_group.adoc
@@ -11,137 +11,134 @@ e|Variables | |
  |{var}float backscatter_at_bottom_i(ping_time, beam) |MA |Backscatter value(imaginary part) at detected bottom, in each beam.
  3+|{attr}:units = "W" 
  3+|{attr}:long_name = "Raw backscatter at bottom (imaginary part)" 
-
+ 
  |{var}float backscatter_at_bottom_r(ping_time, beam) |MA |Backscatter value(real part) at detected bottom, in each beam.
  3+|{attr}:units = "W" 
  3+|{attr}:long_name = "Raw backscatter at bottom (real part)" 
-
+ 
  |{var}float bin_lenght(ping_time) |MA |Distance covered by transmit pulse.
  3+|{attr}:units = "m" 
  3+|{attr}:long_name = "Distance covered by transmit pulse" 
  3+|{attr}float :valid_range = 0.0, 20.0 
-
+ 
  |{var}float bottom_track_velocity_vessel_x(ping_time) |MA |Calculated bottom track velocity, pos in vessel coordinate x direction, forward.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated bottom track velocity value relative own vessel, direction x" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}float bottom_track_velocity_vessel_y(ping_time) |MA |Calculated bottom track velocity, pos in vessel coordinate y direction, starboard.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated bottom track velocity value relative own vessel, direction y" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}float bottom_track_velocity_vessel_z(ping_time) |MA |Calculated bottom track velocity, pos in vessel coordinate z direction, down.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated bottom track velocity value relative own vessel, direction z" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
- |{var}sample_t correlation(ping_time, beam) |MA |Calculated beam correlation. Each element in the 2D 
-matrix is a variable length vector (of type sample_t)
-that contains the calculated correlation along that
-beam and ping time. 
+ 
+ |{var}sample_t correlation(ping_time, beam) |MA |Calculated beam correlation. Each element in the 2D matrix is a variable length vector (of type sample_t)that contains the calculated correlation along that beam and ping time
  3+|{attr}:units = "%" 
  3+|{attr}:long_name = "Calculated beam correlation" 
  3+|{attr}float :valid_range = 0.0, 100.0 
-
+ 
  |{var}int correlation_at_bottom(ping_time, beam) |MA |Correlation at detected bottom, in each beam.
  3+|{attr}:units = "%" 
  3+|{attr}:long_name = "Calculated beam correlation at bottom depth" 
  3+|{attr}int :valid_range = 0, 100 
-
+ 
  |{var}float correlation_factor_limit(ping_time) |MA |Filtering parameter. Element discarded if correlation below given limit.
  3+|{attr}:units = "%" 
  3+|{attr}:long_name = "Correlation minimum limit used for filtering current ping" 
  3+|{attr}float :valid_range = 0.0, 100.0 
-
+ 
  |{var}sample_v current_velocity_geographical_down(ping_time) |MA |Calculated water column current velocity, pos in down direction.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated water current velocity values for the geographical down direction" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}sample_v current_velocity_geographical_east(ping_time) |MA |Calculated water column current velocity, pos in east direction.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated water current velocity values for the geographical east direction" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}sample_v current_velocity_geographical_north(ping_time) |MA |Calculated water column current velocity, pos in north direction.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated water current velocity values for the geographical north direction" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}sample_v current_velocity_vessel_x(ping_time) |O |Calculated vessel relative water column current velocity, in x direction.
  3+|{attr}:units = "m/s" 
- 3+|{attr}:long_name = "Calculated water current velocity values relative own vessel, direction x"
+ 3+|{attr}:long_name = "Calculated water current velocity values relative own vessel, direction x" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}sample_v current_velocity_vessel_y(ping_time) |O |Calculated vessel relative water column current velocity, in y direction.
  3+|{attr}:units = "m/s" 
- 3+|{attr}:long_name = "Calculated water current velocity values relative own vessel, direction y"
+ 3+|{attr}:long_name = "Calculated water current velocity values relative own vessel, direction y" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}sample_v current_velocity_vessel_z(ping_time) |O |Calculated vessel relative water column current velocity, in z direction.
  3+|{attr}:units = "m/s" 
- 3+|{attr}:long_name = "Calculated water current velocity values relative own vessel, direction z"
+ 3+|{attr}:long_name = "Calculated water current velocity values relative own vessel, direction z" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}float depth_first_sample_center(ping_time) |MA |Depth from surface to first valid sample center.
  3+|{attr}:units = "m" 
- 3+|{attr}:long_name = "Depth from surface to first valid sample center"
-
+ 3+|{attr}:long_name = "Depth from surface to first valid sample center" 
+ 
  |{var}sample_v error_velocity(ping_time) |O |Calculated error velocity, Quality factor, low value indicates homogenous water current layer and high measurement quality.
  3+|{attr}:units = "m/s" 
- 3+|{attr}:long_name = "Calculated error velocity"
+ 3+|{attr}:long_name = "Calculated error velocity" 
  3+|{attr}float :valid_min = 0.0 
-
+ 
  |{var}float error_velocity_limit(ping_time) |MA |Filtering parameter. Vessel and geographical current velocity sample discarded if error velocity is above given limit.
  3+|{attr}:units = "m/s" 
- 3+|{attr}:long_name = "Error velocity maximum limit used for filtering current ping"
+ 3+|{attr}:long_name = "Error velocity maximum limit used for filtering current ping" 
  3+|{attr}float :valid_range = 0.0, 100.0 
-
+ 
  |{var}float transmit_duration_nominal_sub_pulse(ping_time) |MA |Nominal duration of the transmit sub-pulse. This is in the case where the transmitted pulse consists of a series of sub-pulses. ADCP specific.
  3+|{attr}:units = "s" 
- 3+|{attr}:long_name = "Nominal duration of the transmitted sub-pulse"
+ 3+|{attr}:long_name = "Nominal duration of the transmitted sub-pulse" 
  3+|{attr}float :valid_min = 0.0 
-
+ 
  |{var}float transmit_lag_interval_sub_pulse(ping_time) |MA |Lag interval between the transmitted sub-pulse.This is in the case where the transmitted pulse consists of a series of sub-pulses. ADCP specific.
  3+|{attr}:units = "s" 
- 3+|{attr}:long_name = "Lag interval of the transmitted sub-pulse"
+ 3+|{attr}:long_name = "Lag interval of the transmitted sub-pulse" 
  3+|{attr}float :valid_min = 0.0 
-
+ 
  |{var}int quality(ping_time) |MA |Quality percent for each depth cell.
  3+|{attr}:units = "%" 
  3+|{attr}:long_name = "Quality indicator for the water current velocity calculation" 
  3+|{attr}int :valid_range = 0, 100 
-
+ 
  |{var}float scaling_factor |MA |Scaling factor from ADCP calibration used in velocity calculations.
  3+|{attr}:long_name = "Scaling factor for velocity calculations" 
  3+|{attr}float :valid_range = 0.0, 2.0 
-
+ 
  |{var}float slant_range_to_bottom(ping_time, beam) |MA |Detected bottom in each beam.
  3+|{attr}:units = "m" 
  3+|{attr}:long_name = "Slant range to bottom for each beam" 
-
+ 
  |{var}int sv_dbw_high_limit(ping_time) |MA |Filtering parameter. Element discarded if backscatter is above given limit.
  3+|{attr}:units = "dB" 
  3+|{attr}:long_name = "Sv maximum limit used for filtering current ping" 
  3+|{attr}int :valid_range = -235, 0 
-
+ 
  |{var}int sv_dbw_low_limit(ping_time) |MA |Filtering parameter. Element discarded if backscatter is below given limit.
  3+|{attr}:units = "dB" 
  3+|{attr}:long_name = "Sv minimum limit used for filtering current ping" 
  3+|{attr}int :valid_range = -235, 0 
-
+ 
  |{var}sample_v velocity(ping_time, beam) |O |Calculated beam velocity. Each element in the 2D matrix is a variable length vector that contains the calculated velocity along that beam and ping time.
  3+|{attr}:units = "m/s" 
- 3+|{attr}:long_name = "Calculated beam velocity"
+ 3+|{attr}:long_name = "Calculated beam velocity" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}beam_stabilisation_t velocity_depth_stabilisation(ping_time) |MA |Indicates whether samples used for velocity vector calculation have been compensated for platform motion.
- 3+|{attr}:long_name = "Velocity depth stabilization applied (or not) "
-
+ 3+|{attr}:long_name = "Velocity depth stabilization applied (or not) " 
+ 
  |{var}beam_stabilisation_t velocity_motion_stabilisation(ping_time) |MA |Indicates whether beam velocities have been compensated for platform motion.
- 3+|{attr}:long_name = "Velocity motion stabilization applied (or not) "
-
+ 3+|{attr}:long_name = "Velocity motion stabilization applied (or not) " 
+ 
  |{var}float vertical_sample_interval(ping_time) |M |True vertical distance between calculated geographical or vessel relative current values.
  3+|{attr}:units = "m" 
  3+|{attr}:long_name = "Distance between recorded data samples" 

--- a/docs/tableAnnotation.adoc
+++ b/docs/tableAnnotation.adoc
@@ -18,6 +18,6 @@ e|Variables | |
  |{var}string annotation_category(time) |O |Optional category for the annotation, for use in grouping annotation types.
  3+|{attr}:long_name = "Annotation category" 
  
- |{var}string annotation_text(time) |O |
+ |{var}string annotation_text(time) |MA |
  3+|{attr}:long_name = "Annotation text" 
 |===

--- a/docs/tableAnnotation.adoc
+++ b/docs/tableAnnotation.adoc
@@ -2,22 +2,22 @@
 :attr: {var}{var}
 [%autowidth,options="header",]
 |===
- |Description|Obligation|Comment
-e|Dimensions||
- |{var}time = unlimited||Can be of fixed or unlimited length, as appropriate.
+|Description |Obligation |Comment
+e|Dimensions | |
+ |{var}time = unlimited | |Can be of fixed or unlimited length, as appropriate.
  
-e|Coordinate variable||
- |{var}uint64 time(time)|MA|
- 3+|{attr}:axis = "T"
- 3+|{attr}:calendar = "gregorian"
- 3+|{attr}:long_name = "Timestamps of annotations"
- 3+|{attr}:standard_name = "time"
- 3+|{attr}:units =  "nanoseconds since 1601-01-01 00:00:00Z"
+e|Coordinate variables | |
+ |{var}uint64 time(time) |MA |
+ 3+|{attr}:axis = "T" 
+ 3+|{attr}:calendar = "gregorian" 
+ 3+|{attr}:long_name = "Timestamps of annotations" 
+ 3+|{attr}:standard_name = "time" 
+ 3+|{attr}:units = "nanoseconds since 1970-01-01 00:00:00Z" or "nanoseconds since 1601-01-01 00:00:00Z" 
  
-e|Variables||
- |{var}string annotation_category(time)|O|Optional category for the annotation, for use in grouping annotation types.
- 3+|{attr}:long_name = "Annotation category"
+e|Variables | |
+ |{var}string annotation_category(time) |O |Optional category for the annotation, for use in grouping annotation types.
+ 3+|{attr}:long_name = "Annotation category" 
  
- |{var}string annotation_text(time)|MA|
- 3+|{attr}:long_name = "Annotation text"
+ |{var}string annotation_text(time) |O |
+ 3+|{attr}:long_name = "Annotation text" 
 |===

--- a/docs/tableAttitude_sub_group.adoc
+++ b/docs/tableAttitude_sub_group.adoc
@@ -15,7 +15,7 @@ e|Coordinate variables | |
  3+|{attr}:calendar = "gregorian" 
  3+|{attr}:long_name = "Timestamps for attitude data" 
  3+|{attr}:standard_name = "time" 
- 3+|{attr}:units = "nanoseconds since 1601-01-01 00:00:00Z" 
+ 3+|{attr}:units = "nanoseconds since 1970-01-01 00:00:00Z" or "nanoseconds since 1601-01-01 00:00:00Z" 
  
 e|Variables | |
  |{var}float heading(time) |MA |Platform heading. Measured clockwise from north.

--- a/docs/tableBeamGridGroup1.adoc
+++ b/docs/tableBeamGridGroup1.adoc
@@ -51,7 +51,7 @@ e|Variables | |
  3+|{attr}:calendar = "gregorian" 
  3+|{attr}:long_name = "Mean time-stamp of each cell" 
  3+|{attr}:standard_name = "time" 
- 3+|{attr}:units = "nanoseconds since 1601-01-01 00:00:00Z" 
+ 3+|{attr}:units = "nanoseconds since 1970-01-01 00:00:00Z" or "nanoseconds since 1601-01-01 00:00:00Z" 
  3+|{attr}:coordinates = "ping_axis platform_latitude platform_longitude" 
  
  |{var}float integrated_backscatter(ping_axis, range_axis, frequency) |M |Integrated backscatter measurement.
@@ -229,18 +229,18 @@ e|Variables | |
  3+|{attr}:coordinates = "ping_axis cell_latitude cell_longitude" 
  3+|{attr}double :_FillValue = Double.NaN 
  
- |{var}float cell_depth(range_axis, beam) |M |Depth of the  cell to the water line (distance are positives downwards).
- 3+|{attr}:long_name = "Cell depth below water line"
+ |{var}float cell_depth(range_axis, beam) |M |Depth of the cell to the water line (distance are positives downwards).
+ 3+|{attr}:long_name = "Cell depth below water line" 
  3+|{attr}:units = "m" 
  
  |{var}float tx_transducer_depth(ping_axis) |O |Tx transducer depth below waterline at time of the cell (distance are positives downwards).
  3+|{attr}:long_name = "Tx transducer depth below waterline" 
  3+|{attr}:units = "m" 
- 3+|{attr}:coordinates = "ping_axis platform_latitude platform_longitude"
-
+ 3+|{attr}:coordinates = "ping_axis platform_latitude platform_longitude" 
+ 
  |{var}float waterline_to_chart_datum(ping_axis) |O |Vertical translation vector at the time of the ping matching the distance from the water line to the chart data reference (typically Lowest Astronomical Tide or Mean Sea Level). This variable is the vector that contains the tide and allows for the positioning of samples in an absolute reference system.
- 3+|{attr}:long_name = "vertical translation from waterline to chart datum reference "
- 3+|{attr}:units = "m"
- 3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude"
+ 3+|{attr}:long_name = "vertical translation from waterline to chart datum reference " 
+ 3+|{attr}:units = "m" 
+ 3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude" 
  2+|{attr}:vertical_coordinate_reference_system = "MSL depth" |The vertical datum to which distance are referred to. Possible values are 'MSL Depth' or 'LAT Depth'
 |===

--- a/docs/tableBeamGridGroup1.adoc
+++ b/docs/tableBeamGridGroup1.adoc
@@ -219,7 +219,6 @@ e|Variables | |
  3+|{attr}:units = "degrees_north" 
  3+|{attr}:long_name = "latitude" 
  3+|{attr}:coordinates = "ping_axis cell_latitude cell_longitude" 
- 3+|{attr}double :_FillValue = Double.NaN 
  
  |{var}double cell_longitude(ping_axis, range_axis, beam) |M |Mean longitude of the echoes contributing to the cell in WGS-84 reference system.
  3+|{attr}double :valid_range = −180.0, 180.0 
@@ -227,7 +226,6 @@ e|Variables | |
  3+|{attr}:units = "degrees_east" 
  3+|{attr}:long_name = "longitude" 
  3+|{attr}:coordinates = "ping_axis cell_latitude cell_longitude" 
- 3+|{attr}double :_FillValue = Double.NaN 
  
  |{var}float cell_depth(range_axis, beam) |M |Depth of the cell to the water line (distance are positives downwards).
  3+|{attr}:long_name = "Cell depth below water line" 

--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -18,9 +18,6 @@ e|Dimensions | |
  |{var}subbeam | |The number of sub-beams in these beams.
  |{var}ping_time = unlimited | |Can be of fixed or unlimited length, as appropriate.
  |{var}tx_beam | |The number of transmit beams in this beam group
- |{var}mean_time = unlimited | |Can be of fixed or unlimited length, as appropriate.
-
-
  
 e|Coordinate variables | |
  |{var}string beam(beam) |M |Beam name (or number or identification code).
@@ -30,14 +27,6 @@ e|Coordinate variables | |
  3+|{attr}:axis = "T" 
  3+|{attr}:calendar = "gregorian" 
  3+|{attr}:long_name = "Time-stamp of each ping" 
- 3+|{attr}:standard_name = "time" 
- 3+|{attr}:units = "nanoseconds since 1970-01-01 00:00:00Z" or "nanoseconds since 1601-01-01 00:00:00Z" 
- 3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude" 
- 
- |{var}uint64 mean_time(mean_time) |M |Timestamp for the center of an averaging period.
- 3+|{attr}:axis = "T" 
- 3+|{attr}:calendar = "gregorian" 
- 3+|{attr}:long_name = "Time-stamp for the center of each averaged value" 
  3+|{attr}:standard_name = "time" 
  3+|{attr}:units = "nanoseconds since 1970-01-01 00:00:00Z" or "nanoseconds since 1601-01-01 00:00:00Z" 
  3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude" 

--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -8,7 +8,7 @@ e|Group attributes | |
  |{attr}conversion_equation_t :conversion_equation_type |M |Type of equation used to convert backscatter measurements into volume backscattering strength and target strength.
  |{attr}int :preferred_MRU |MA |Index of the MRU sensor to use by default. If the sensor used can be dynamically changed, refer to the variable active_MRU. Index matches the ones used in the Platform MRU sensors variables.
  |{attr}int :preferred_position |MA |Index of the position sensor to use by default. If the sensor used can be dynamically changed, refer to the variable active_position_sensor. Index matches the ones used in the Platform position sensors variables.
-
+ 
 e|Types | |
  2+|{var}float(*) sample_t |Variable length vector used to store ragged arrays of backscatter data. Data type can be varied to suit data storage needs.
  2+|{var}float(*) angle_t |Variable length vector used to store ragged arrays of split-aperture angles. Data type can varied to suit data storage needs.

--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -250,7 +250,6 @@ e|Variables | |
  3+|{attr}:units = "degrees_north" 
  3+|{attr}:long_name = "latitude" 
  3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude" 
- 3+|{attr}double :_FillValue = Double.NaN 
  
  |{var}double platform_longitude(ping_time) |M |Longitude of the platform reference point in WGS-84 reference system at the time of the ping.
  3+|{attr}double :valid_range = −180.0, 180.0 
@@ -258,7 +257,6 @@ e|Variables | |
  3+|{attr}:units = "degrees_east" 
  3+|{attr}:long_name = "longitude" 
  3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude" 
- 3+|{attr}double :_FillValue = Double.NaN 
  
  |{var}float platform_heading(ping_time) |M |Heading of the platform at time of the ping.
  3+|{attr}:standard_name = "platform_orientation" 

--- a/docs/tableMean_current_sub_group.adoc
+++ b/docs/tableMean_current_sub_group.adoc
@@ -3,6 +3,20 @@
 [%autowidth,options="header",]
 |===
 |Description |Obligation |Comment
+e|Types | |
+ 2+|{var}uint64(*) ping_t |Variable length vector used to store ping time of pings used in averaging.
+
+e|Dimensions | |
+ |{var}mean_time = unlimited | |Can be of fixed or unlimited length, as appropriate.
+ 
+e|Coordinate variables | |
+ |{var}uint64 mean_time(mean_time) |M |Timestamp for the center of an averaging period.
+ 3+|{attr}:axis = "T" 
+ 3+|{attr}:calendar = "gregorian" 
+ 3+|{attr}:long_name = "Time-stamp of each ping" 
+ 3+|{attr}:standard_name = "time" 
+ 3+|{attr}:units = "nanoseconds since 1970-01-01 00:00:00Z" or "nanoseconds since 1601-01-01 00:00:00Z" 
+ 
 e|Variables | |
  |{var}int averaging(mean_time) |M |Number of ping averages.
  3+|{attr}:long_name = "Number of ping averages" 
@@ -61,45 +75,38 @@ e|Variables | |
  |{var}double mean_platform_heading(mean_time) |MA |Calculated mean heading for the averaging period.
  3+|{attr}:units = "degrees_north" 
  3+|{attr}:long_name = "Calculated mean heading for the averaging period." 
- 3+|{attr}float :valid_range = 0.0, 360.0 
+ 3+|{attr}double :valid_range = 0.0, 360.0 
  
  |{var}double mean_platform_latitude(mean_time) |MA |Latitude representing the averaging period.
  3+|{attr}:units = "degrees_north" 
  3+|{attr}:long_name = "Latitude representing the averaging period." 
- 3+|{attr}float :valid_range = -90.0, 90.0 
+ 3+|{attr}double :valid_range = -90.0, 90.0 
  
  |{var}double mean_platform_longitude(mean_time) |MA |Longitude representing the averaging period.
  3+|{attr}:units = "degrees_east" 
  3+|{attr}:long_name = "Longitude representing the averaging period." 
- 3+|{attr}float :valid_range = -180.0, 180.0 
+ 3+|{attr}double :valid_range = -180.0, 180.0 
  
  |{var}double mean_platform_pitch(mean_time) |MA |Calculated mean pitch for the averaging period.
  3+|{attr}:units = "arc_degree" 
  3+|{attr}:long_name = "Calculated mean pitch for the averaging period." 
- 3+|{attr}float :valid_range = -90.0, 90.0 
+ 3+|{attr}double :valid_range = -90.0, 90.0 
  
  |{var}double mean_platform_roll(mean_time) |MA |Calculated mean roll for the averaging period.
  3+|{attr}:units = "arc_degree" 
  3+|{attr}:long_name = "Calculated mean roll for the averaging period." 
- 3+|{attr}float :valid_range = -90.0, 90.0 
+ 3+|{attr}double :valid_range = -90.0, 90.0 
  
  |{var}double mean_platform_vertical(mean_time) |MA |Calculated mean vertical offset for the averaging period.
  3+|{attr}:units = "m" 
  3+|{attr}:long_name = "Calculated mean vertical offset for the averaging period. Zero if velocity_depth_stabilisation is true." 
- 
- |{var}uint64 mean_time(mean_time) |MA |Timestamp at which each ping occurred.
- 3+|{attr}:axis = "T" 
- 3+|{attr}:calendar = "gregorian" 
- 3+|{attr}:long_name = "TBD" 
- 3+|{attr}:standard_name = "time" 
- 3+|{attr}:units = "nanoseconds since 1601-01-01 00:00:00Z" 
  
  |{var}float percent_good_limit |MA |Filtering parameter. Mean velocity value disgarded if quality below given limit.
  3+|{attr}:units = "%" 
  3+|{attr}:long_name = "Percent good limit used to filter the water current velocities" 
  3+|{attr}float :valid_range = 0.0, 100.0 
  
- |{var}Ping_t ping_averaged(mean_time) |MA |Reference to pings (by ping_time) used for averaging to find start-end of lat, lon, vessel speed, heading etc.
+ |{var}ping_t ping_averaged(mean_time) |MA |Reference to pings (by ping_time) used for averaging to find start-end of lat, lon, vessel speed, heading etc.
  3+|{attr}:long_name = "Time reference to pings used for averaging" 
  
  |{var}int quality(mean_time) |MA |Averaged quality in percent for each depth cell.

--- a/docs/tableMean_current_sub_group.adoc
+++ b/docs/tableMean_current_sub_group.adoc
@@ -4,105 +4,105 @@
 |===
 |Description |Obligation |Comment
 e|Variables | |
-  |{var}int averaging(mean_time) |M |Number of ping averages.
+ |{var}int averaging(mean_time) |M |Number of ping averages.
  3+|{attr}:long_name = "Number of ping averages" 
  3+|{attr}int :valid_min = 1 
-
-  |{var}float bottom_track_velocity_vessel_x(mean_time) |MA |Calculated bottom track velocity, pos in vessel coordinate x direction, forward.
+ 
+ |{var}float bottom_track_velocity_vessel_x(mean_time) |MA |Calculated bottom track velocity, pos in vessel coordinate x direction, forward.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated mean bottom track velocity value relative own vessel, direction x" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
-  |{var}float bottom_track_velocity_vessel_y(mean_time) |MA |Calculated bottom track velocity, pos in vessel coordinate y direction, starboard.
+ 
+ |{var}float bottom_track_velocity_vessel_y(mean_time) |MA |Calculated bottom track velocity, pos in vessel coordinate y direction, starboard.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated mean bottom track velocity value relative own vessel, direction y" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}float bottom_track_velocity_vessel_z(mean_time) |MA |Calculated bottom track velocity, pos in vessel coordinate z direction, down.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated mean bottom track velocity value relative own vessel, direction z" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}sample_v current_velocity_geographical_down(mean_time) |MA |Calculated water column current velocity, pos in down direction.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated mean water current velocity values for the geographical down direction" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}sample_v current_velocity_geographical_east(mean_time) |MA |Calculated water column current velocity, pos in east direction.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated mean water current velocity values for the geographical east direction" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}sample_v current_velocity_geographical_north(mean_time) |MA |Calculated water column current velocity, pos in north direction.
  3+|{attr}:units = "m/s" 
  3+|{attr}:long_name = "Calculated mean water current velocity values for the geographical north direction" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
-  |{var}sample_v current_velocity_vessel_x(mean_time) |MA |Calculated vessel relative water column current velocity, in x direction.
+ 
+ |{var}sample_v current_velocity_vessel_x(mean_time) |MA |Calculated vessel relative water column current velocity, in x direction.
  3+|{attr}:units = "m/s" 
- 3+|{attr}:long_name = "Calculated mean water current velocity values relative own vessel, direction x"
+ 3+|{attr}:long_name = "Calculated mean water current velocity values relative own vessel, direction x" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}sample_v current_velocity_vessel_y(mean_time) |MA |Calculated vessel relative water column current velocity, in y direction.
  3+|{attr}:units = "m/s" 
- 3+|{attr}:long_name = "Calculated mean water current velocity values relative own vessel, direction y"
+ 3+|{attr}:long_name = "Calculated mean water current velocity values relative own vessel, direction y" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}sample_v current_velocity_vessel_z(mean_time) |MA |Calculated vessel relative water column current velocity, in z direction.
  3+|{attr}:units = "m/s" 
- 3+|{attr}:long_name = "Calculated mean water current velocity values relative own vessel, direction z"
+ 3+|{attr}:long_name = "Calculated mean water current velocity values relative own vessel, direction z" 
  3+|{attr}float :valid_range = -50.0, 50.0 
-
+ 
  |{var}float mean_bin_lenght(mean_time) |MA |Distance covered by transmit pulse.
  3+|{attr}:units = "m" 
  3+|{attr}:long_name = "Distance covered by transmit pulse" 
  3+|{attr}float :valid_range = 0.0, 20.0 
-
+ 
  |{var}double mean_platform_heading(mean_time) |MA |Calculated mean heading for the averaging period.
  3+|{attr}:units = "degrees_north" 
  3+|{attr}:long_name = "Calculated mean heading for the averaging period." 
  3+|{attr}float :valid_range = 0.0, 360.0 
-
+ 
  |{var}double mean_platform_latitude(mean_time) |MA |Latitude representing the averaging period.
  3+|{attr}:units = "degrees_north" 
  3+|{attr}:long_name = "Latitude representing the averaging period." 
  3+|{attr}float :valid_range = -90.0, 90.0 
-
+ 
  |{var}double mean_platform_longitude(mean_time) |MA |Longitude representing the averaging period.
  3+|{attr}:units = "degrees_east" 
  3+|{attr}:long_name = "Longitude representing the averaging period." 
  3+|{attr}float :valid_range = -180.0, 180.0 
-
+ 
  |{var}double mean_platform_pitch(mean_time) |MA |Calculated mean pitch for the averaging period.
  3+|{attr}:units = "arc_degree" 
  3+|{attr}:long_name = "Calculated mean pitch for the averaging period." 
  3+|{attr}float :valid_range = -90.0, 90.0 
-
+ 
  |{var}double mean_platform_roll(mean_time) |MA |Calculated mean roll for the averaging period.
  3+|{attr}:units = "arc_degree" 
  3+|{attr}:long_name = "Calculated mean roll for the averaging period." 
  3+|{attr}float :valid_range = -90.0, 90.0 
-
+ 
  |{var}double mean_platform_vertical(mean_time) |MA |Calculated mean vertical offset for the averaging period.
  3+|{attr}:units = "m" 
  3+|{attr}:long_name = "Calculated mean vertical offset for the averaging period. Zero if velocity_depth_stabilisation is true." 
-
+ 
  |{var}uint64 mean_time(mean_time) |MA |Timestamp at which each ping occurred.
  3+|{attr}:axis = "T" 
  3+|{attr}:calendar = "gregorian" 
  3+|{attr}:long_name = "TBD" 
  3+|{attr}:standard_name = "time" 
  3+|{attr}:units = "nanoseconds since 1601-01-01 00:00:00Z" 
-
+ 
  |{var}float percent_good_limit |MA |Filtering parameter. Mean velocity value disgarded if quality below given limit.
  3+|{attr}:units = "%" 
  3+|{attr}:long_name = "Percent good limit used to filter the water current velocities" 
  3+|{attr}float :valid_range = 0.0, 100.0 
-
+ 
  |{var}Ping_t ping_averaged(mean_time) |MA |Reference to pings (by ping_time) used for averaging to find start-end of lat, lon, vessel speed, heading etc.
  3+|{attr}:long_name = "Time reference to pings used for averaging" 
-
-  |{var}int quality(mean_time) |MA |Averaged quality in percent for each depth cell.
+ 
+ |{var}int quality(mean_time) |MA |Averaged quality in percent for each depth cell.
  3+|{attr}:units = "%" 
  3+|{attr}:long_name = "Quality indicator for the water current velocity calculation" 
  3+|{attr}int :valid_range = 0, 100 

--- a/docs/tablePosition_sub_group.adoc
+++ b/docs/tablePosition_sub_group.adoc
@@ -25,7 +25,6 @@ e|Variables | |
  3+|{attr}:units = "degrees_north" 
  3+|{attr}:long_name = "latitude" 
  3+|{attr}:coordinates = "time latitude longitude" 
- 3+|{attr}double :_FillValue = Double.NaN 
  
  |{var}double longitude(time) |M |Longitude of the platform reference point in WGS-84 reference system
  3+|{attr}double :valid_range = −180.0, 180.0 
@@ -33,7 +32,6 @@ e|Variables | |
  3+|{attr}:units = "degrees_east" 
  3+|{attr}:long_name = "longitude" 
  3+|{attr}:coordinates = "time latitude longitude" 
- 3+|{attr}double :_FillValue = Double.NaN 
  
  |{var}float heading(time) |MA |Heading refers to the direction a platform is pointing. This may or may not be the direction that the platform actually travels, which is known as its course or track. Any difference between course and heading is due to the motion of the underlying medium, the air or water, or other effects like skidding or slipping. Heading is typically based on compass directions, so 0° (or 360°) indicates a direction toward true North, 90° indicates a direction toward true East, 180° is true South, and 270° is true West.  
  3+|{attr}:standard_name = "platform_orientation" 


### PR DESCRIPTION
@SverreBerg , @gavinmacaulay  please find a few fixes that request comments if need be.
Those should be merged after #52 and are linked to  #51 

The commit detail is below. I fixed a few mistakes, and what is subject to comment is that ping_t was not well defined. I moved it from ADCP group to Mean_current group where it is really used. Note that in the old ADCP file I have as example, this type ping_t is named ping_reference_type_t and is defined in /Sonar group.

The detail of the commit : 

* Mean_current : fix wrong type in valid_range definition for variables like mean_platform_roll

* Mean_current : Define mean_time as a coordinate variables, remove TBD 

* Move ping_t definition from ADCP to Mean_current (only used here) and fix its definition

* Remove useless mean_time from tableBeamGroup (probably bad copy paste)
 
