### PR TITLE
Clarify type 5 data

### DIFF
--- a/docs/crr341.adoc
+++ b/docs/crr341.adoc
@@ -494,7 +494,7 @@ Type 4 conversion equations are intended for data produced by Simrad EK80 and ES
 
 Type 5 conversion equation is intended for sonars for which the sonar manufacturer computes standard TS and Sv values as defined in  MacLennan et al. (2002).
 
-Using equation 5, the Sv value is directly stored in the _backscatter_r_ variable and/or the TS value is directly stored in the _backscatter_i_ variable
+Using equation 5, the Sv value is directly stored in the _backscatter_r_ variable and/or the TS value is directly stored in the _backscatter_i_ variable. It is permitted to store only Sv or only TS values, meaning that a file could have just a _backscatter_r_ variable, just a _backscatter_i_ variable, or both.
 
 === Type 6
 
@@ -1002,6 +1002,7 @@ Platform and Sonar:: The transducer description now allows for separate emitting
 Beam:: 
 * Added variables for the description and storage of data from split-aperture beams via a subbeam dimension added in the Sonar group.
 * transmit_frequency_start and transmit_frequency_stop cannot now collapse the beam dimension if all start or stop values are the same (while this increases storage, it will reduce complexity)
+* Explicitly allow for type 5 data to have only Sv, only TS, or both in a file.
 
 Gridded:: A new subgroup, Gridded is added to allow for gridded backscatter data (i.e., resampled onto a consistent time/range grid).
 

--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -35,15 +35,16 @@ e|Variables | |
  |{var}sample_t backscatter_i(ping_time, beam, subbeam) |MA |Imaginary part of backscatter measurements (or for type 5 equations, TS values). Each element in the 3D matrix is a variable length vector (of type sample_t) that contains the samples for that beam, ping time, and optionally subbeam.
  3+|{attr}:long_name = "Raw backscatter measurements (imaginary part)" 
  2+|{attr}:units = "as appropriate" |Use units appropriate for the data.
- 
- |{var}sample_t backscatter_r(ping_time, beam, subbeam) |M |Real part or amplitude or power of backscatter measurements. Each element in the 3D matrix is a variable length vector (of type sample_t) that contains the samples for that beam, ping time, and optionally subbeam.
- 3+|{attr}:long_name = "Raw backscatter measurements (real part)" 
- 2+|{attr}:units = "as appropriate" |Use units appropriate for the data.
 
  |{var}int sample_count(ping_time, beam)|O|The number of samples in each beam/ping in the backscatter_r and backscatter_i variables. This value is not essential, but software that reads the backscatter_r and backscatter_i variables can use it to significantly improve data loading times.
  3+|{attr}:long_name = "Number of samples in each beam, per ping"
  3+|{attr}:units = "1"
  3+|{attr}:int valid_min = 0
+
+ |{var}sample_t backscatter_r(ping_time, beam, subbeam) |M |Real part or amplitude or power of backscatter measurements. Each element in the 3D matrix is a variable length vector (of type sample_t) that contains the samples for that beam, ping time, and optionally subbeam.
+ 3+|{attr}:long_name = "Raw backscatter measurements (real part)" 
+ 2+|{attr}:units = "as appropriate" |Use units appropriate for the data.
+
 
  |{var}angle_t echoangle_major(ping_time, beam) |MA |Electrical phase angle of the incoming echoes at time ping_time relative to the direction of each beam. Only required if the beam_type variable for this ping_time is set to split_aperture_angles.
  3+|{attr}:long_name = "Echo arrival angle in the major beam coordinate" 

--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -45,7 +45,6 @@ e|Variables | |
  3+|{attr}:long_name = "Raw backscatter measurements (real part)" 
  2+|{attr}:units = "as appropriate" |Use units appropriate for the data.
 
-
  |{var}angle_t echoangle_major(ping_time, beam) |MA |Electrical phase angle of the incoming echoes at time ping_time relative to the direction of each beam. Only required if the beam_type variable for this ping_time is set to split_aperture_angles.
  3+|{attr}:long_name = "Echo arrival angle in the major beam coordinate" 
  3+|{attr}:units = "arc_degree" 

--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -32,11 +32,11 @@ e|Coordinate variables | |
  3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude" 
  
 e|Variables | |
- |{var}sample_t backscatter_i(ping_time, beam, subbeam) |MA |Imaginary part of backscatter measurements. Each element in the 3D matrix is a variable length vector (of type sample_t) that contains the samples for that beam, ping time, and optionally subbeam.
+ |{var}sample_t backscatter_i(ping_time, beam, subbeam) |MA |Imaginary part of backscatter measurements (or for type 5 equations, TS values). Each element in the 3D matrix is a variable length vector (of type sample_t) that contains the samples for that beam, ping time, and optionally subbeam.
  3+|{attr}:long_name = "Raw backscatter measurements (imaginary part)" 
  2+|{attr}:units = "as appropriate" |Use units appropriate for the data.
  
- |{var}sample_t backscatter_r(ping_time, beam, subbeam) |M |Real part or amplitude or power of backscatter measurements. Each element in the 3D matrix is a variable length vector (of type sample_t) that contains the samples for that beam, ping time, and optionally subbeam.
+ |{var}sample_t backscatter_r(ping_time, beam, subbeam) |M |Real part or amplitude or power of backscatter measurements (or for type 5 equations, Sv values). Each element in the 3D matrix is a variable length vector (of type sample_t) that contains the samples for that beam, ping time, and optionally subbeam.
  3+|{attr}:long_name = "Raw backscatter measurements (real part)" 
  2+|{attr}:units = "as appropriate" |Use units appropriate for the data.
  


### PR DESCRIPTION
Explicitly allow type 5 data to be just Sv, just TS, or both in a file. Addresses #60.