### PR TITLE
Fix inconsistency in ISO8601 timestamp version

### DIFF
--- a/docs/crr341.adoc
+++ b/docs/crr341.adoc
@@ -1010,6 +1010,8 @@ Gridded:: A new subgroup, Gridded is added to allow for gridded backscatter data
 
 ADCP:: A new subgroup, ADCP, has been added to store data from acoustic Doppler current profilers.
 
+Provenance:: Changed the required timestamp format to match that used elsewhere in the convention.
+
 === Changes within a document version 
 
 [cols=",,,",options="header",]

--- a/docs/tableProvenance.adoc
+++ b/docs/tableProvenance.adoc
@@ -6,7 +6,7 @@
 e|Group attributes | |
  |{attr}:conversion_software_name |MA |Name of the software used to do the conversion.
  |{attr}:conversion_software_version |MA |Version of the software used to do the conversion.
- |{attr}:conversion_time |MA |Date and time of the start of the conversion process in extended ISO8601:2005 extended format, including time zone.
+ |{attr}:conversion_time |MA |Date and time of the start of the conversion process in ISO8601:2004 extended format, including time zone.
  |{attr}:history |R |Provides an audit trail for modifications to the original data. It should contain a separate line for each modification, with each line beginning with a timestamp and including user name, modification name and modification arguments. for example  2019-09-07T15:50+00Z (John Doe) File conversion by XXX software
  
 e|Dimensions | |


### PR DESCRIPTION
Fix an inconsistency over which ISO8601 timestamp format is used in the convention. Address issue #66