### PR TITLE
change dimension of transmit_transducer_index

### DIFF
--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -257,7 +257,7 @@ e|Variables | |
  3+|{attr}:valid_min = "0" 
  3+|{attr}:long_name = "Receive transducer index" 
  
- |{var}int transmit_transducer_index(ping_time, beam) |MA |Transmitting or monostatic transducer index associated with the given receiving beam
+ |{var}int transmit_transducer_index(ping_time, tx_beam) |MA |Transmitting or monostatic transducer index associated with the given transmit beam
  3+|{attr}:valid_min = "0" 
  3+|{attr}:long_name = "Transmit transducer index" 
  


### PR DESCRIPTION
I think there is a mistake on variable transmit_transducer_index  which allows right now to get the associated transmit transducer index for a given receiving beam.
This variable should refers instead to a transmit beam. Links between receive beams and transmit beam (and its transducer) are done with the transmit_beam_index variable.