### PR TITLE
* Correct type 6 conversion equations

### DIFF
--- a/docs/crr341.adoc
+++ b/docs/crr341.adoc
@@ -664,14 +664,14 @@ where stem:[A] is the amplitude or envelope of the received voltage signal (V), 
 [stem,reftext=({counter:eqs})]
 ++++
 \begin{equation}
-I = \mathrm{Re}\left(z_0\right) + \mathrm{Re}\left(z_1\right),
+I = \frac{\mathrm{Re}\left(z_0\right) + \mathrm{Re}\left(z_1\right)}{2},
 \end{equation}
 ++++
 
 [stem,reftext=({counter:eqs})]
 ++++
 \begin{equation}
-Q = \mathrm{Im}\left(z_0\right) + \mathrm{Im}\left(z_1\right),
+Q = \frac{\mathrm{Im}\left(z_0\right) + \mathrm{Im}\left(z_1\right)}{2},
 \end{equation}
 ++++
 

--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -301,7 +301,7 @@ s|Variables | |
  |{var}transmit_t transmit_type(ping_time, tx_beam) |M |Type of transmit pulse.
  3+|{attr}:long_name = "Type of transmitted pulse" 
 
- |{var}float transmitter_and_receiver_coefficient(ping_time) |MA |Sum of transmit source level (dB re 1 μPa at 1 m), voltage sensitivity (dB re 1 V/μPa), and system gain (dB). Necessary for type 6 conversion equations.
+ |{var}float transmitter_and_receiver_coefficient(ping_time) |MA |Sum of transmit source level (dB re 1 μPa at 1 m), voltage sensitivity for each beam (dB re 1 V/μPa), and system gain (dB). Necessary for type 6 conversion equations.
  3+|{attr}:long_name = "Transmitter and receiver coefficient" 
  3+|{attr}:units = "dB" 
  2+|{attr}int :substitute_value_used = 0 |If non-zero, indicates that the variable value is a nominal value used when a measured or calibrated value is not available for a mandatory variable.


### PR DESCRIPTION
Edited:
-tableBeamGroup1.adoc: Add three words to comment for voltage sensitivity to clarify that the sensitivity is defined for each beam.
-crr341.adoc: Correct equations (21) for I and (22) for Q according to the correct definition of the voltage sensitivity.