### PR TITLE
Fixes induced by Kongsberg EK80 SONAR-netCDF output  

### DIFF
--- a/docs/crr341.adoc
+++ b/docs/crr341.adoc
@@ -260,7 +260,7 @@ include::tableEnvironment.adoc[]
 
 This group contains information about the sonar platform (e.g. ship). The netCDF4 group name is */Platform* and is described in <<platformGroupTable>>. Optionally, subgroups of /Platform can be used to store data from individual instruments that provide measurements about the platform, such as position, attitude, etc (note that if the measurements are about the environment around the platform they should be stored in the /Environment group). This structure must be used to store all instrument data. 
 
-Each platform can contain several instruments of the same type, such as multiple position sensors. Each instrument type is defined as a subgroup of the /Platform group and data for each instrument are stored in a subgroup of the instrument group. Subgroup names for common instrument types are given in <<platformInstrumentsTable>> and how to store data from those instruments are also cross-referenced in <<platformInstrumentsTable>>. For example, data from individual position and attitude instruments are stored as subgroups of the /Platform/Position and /Platform/Attitude subgroups. The names of those subgroups must match the names of the instrument's serial number or identifier as defined in the MRU_ids and position_ids variables in the /Platform group (<<platformGroupTable>>).  Additional instrument type subgroups can be created as required.
+Each platform can contain several instruments of the same type, such as multiple position sensors. Each instrument type is defined as a subgroup of the /Platform group and data for each instrument are stored in a subgroup of the instrument group. Subgroup names for common instrument types are given in <<platformInstrumentsTable>> and how to store data from those instruments are also cross-referenced in <<platformInstrumentsTable>>. For example, data from individual position and attitude instruments are stored as subgroups of the /Platform/Position and /Platform/Attitude subgroups, data from gyroscope instruments are stored as subgroups of the /Platform/Gyro. The names of those subgroups must match the names of the instrument's serial number or identifier as defined in the MRU_ids, position_ids and gyros_ids variables in the /Platform group (<<platformGroupTable>>).  Additional instrument type subgroups can be created as required.
 
 Each instrument group can also store unprocessed and unparsed sensor data. The data format for unprocessed and unparsed data is not prescribed, but could, for example, be NMEA-style text and/or numeric values. These subgroups must have one attribute called “description” that provides a short description of the contents. Other attributes can be added as desired. The variables under the subgroup should have appropriate names and an attribute that gives the units, where appropriate.
 
@@ -281,6 +281,7 @@ include::tablePlatform.adoc[]
 |Sensor or datagram |Subgroup name | Comment
 |Attitude sensors, MRU |Attitude | Use data structure described in <<AttitudeSubGroup>>
 |GPS sensors, Position |Position | Use data structure described in <<PositionSubGroup>>
+|Gyroscope sensors|Gyro| Use data structure described in <<GyroSubGroup>>
 |Clock or time synchronisation datagrams | Clock | 
 |NMEA telegrams | NMEA | Use data structure described in <<NMEATable>>.
 |===
@@ -292,6 +293,10 @@ include::tableAttitude_sub_group.adoc[]
 .Description of a platform position subgroup.
 [[PositionSubGroup]]
 include::tablePosition_sub_group.adoc[]
+
+.Description of a gyroscope attitude subgroup.
+[[GyroSubGroup]]
+include::tableGyro_sub_group.adoc[]
 
 .Suggested group for storing NMEA datagrams from marine instruments.
 [[NMEATable]]

--- a/docs/tableBeamGridGroup1.adoc
+++ b/docs/tableBeamGridGroup1.adoc
@@ -111,8 +111,8 @@ s|Variables | |
  2+|{attr}:units = "as appropriate" |Use units appropriate for the data.
  
  |{var}short non_quantitative_processing(ping_axis) |M |Settings of any processing that is applied prior to recording backscatter data that may prevent the calculation of calibrated backscatter. A value of 0 always indicates no such processing.
- 2+|{attr}:flag_meanings |Space-separated list of non-quantitative processing setting words or phrases. The first item must always be the no non-quantitative processing setting and subsequent items as appropriate to the sonar and data(e.g. ”no_non_quantitative_processing simrad_noise_filter_weak simrad_noise_filter_medium simrad_noise_filter_strong”).
- 2+|{attr}short :flag_values |List of unique values (e.g. 0, 1, 3, 4) that indicate different non-quantitative processing settings that could be present in the sonar data. Must have the same number of values as settings given in the flag_meanings attribute.
+ 2+|{attr}:flag_meanings = "unknown" |Space-separated list of non-quantitative processing setting words or phrases. The first item must always be the no non-quantitative processing setting and subsequent items as appropriate to the sonar and data(e.g. ”no_non_quantitative_processing simrad_noise_filter_weak simrad_noise_filter_medium simrad_noise_filter_strong”).
+ 2+|{attr}short :flag_values = 0 |List of unique values (e.g. 0, 1, 3, 4) that indicate different non-quantitative processing settings that could be present in the sonar data. Must have the same number of values as settings given in the flag_meanings attribute.
  3+|{attr}:long_name = "Presence or not of non-quantitative processing applied to the backscattering data (sonar specific)" 
  3+|{attr}:coordinates = "ping_axis platform_latitude platform_longitude" 
 

--- a/docs/tableBeamGroup1.adoc
+++ b/docs/tableBeamGroup1.adoc
@@ -8,6 +8,7 @@ s|Group attributes | |
  |{attr}conversion_equation_t :conversion_equation_type |M |Type of equation used to convert backscatter measurements into volume backscattering strength and target strength.
  |{attr}int :preferred_MRU |MA |Index of the MRU sensor to use by default. If the sensor used can be dynamically changed, refer to the variable active_MRU. Index matches the ones used in the Platform MRU sensors variables.
  |{attr}int :preferred_position |MA |Index of the position sensor to use by default. If the sensor used can be dynamically changed, refer to the variable active_position_sensor. Index matches the ones used in the Platform position sensors variables.
+ |{attr}int :preferred_gyro |O |Index of the gyro sensor to use by default, If this variable is defined heading is retrieve from the matching sensor. If the sensor used can be dynamically changed, refer to the variable active_gyro_sensor. Index matches the ones used in the Platform position sensors variables.
  
 s|Types | |
  2+|{var}float(*) sample_t |Variable length vector used to store ragged arrays of backscatter data. Data type can be varied to suit data storage needs.
@@ -48,6 +49,11 @@ s|Variables | |
  3+|{attr}:valid_min = "0" 
  3+|{attr}:long_name = "Active position sensor index" 
  3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude" 
+ 
+ |{var}int active_gyro_sensor(ping_time) |MA |Indicate the index of the gyro sensor used at the time of the ping to compute the platform heading.
+ 3+|{attr}:valid_min = "0" 
+ 3+|{attr}:long_name = "Active gyro sensor index" 
+ 3+|{attr}:coordinates = "platform_latitude platform_longitude" 
  
  |{var}sample_t backscatter_i(ping_time, beam, subbeam) |MA |Imaginary part of backscatter measurements (or for type 5 equations, TS values). Each element in the 3D matrix is a variable length vector (of type sample_t) that contains the samples for that beam, ping time, and optionally subbeam.
  3+|{attr}:long_name = "Raw backscatter measurements (imaginary part)" 
@@ -91,11 +97,6 @@ s|Variables | |
  3+|{attr}:units = "s" 
  3+|{attr}:valid_min = "0.0" 
 
- |{var}float calibrated_frequency(frequency) |M |Frequencies for which on-axis gain values have been estimated during the calibration exercise.
- 3+|{attr}:long_name = "Calibration gain frequencies" 
- 3+|{attr}:units = "Hz" 
- 3+|{attr}float :valid_min = 0.0 
- 
  |{var}float detected_bottom_range(ping_time, beam) |O |Range from the transducer face where the bottom detection criteria were encountered for the amplitude or the phase of the backscattered echoes. The range of the bottom at index bottom_index with a monostatic transducer and if a constant sound speed is applied is given by detected_bottom_range= sound_speed_at_transducer*(blanking_interval+bottom_index*sample_interval - sample_time_offset)/2.
  3+|{attr}:long_name = "Detected range of the bottom" 
  3+|{attr}:units = "m" 
@@ -133,8 +134,8 @@ s|Variables | |
  2+|{attr}int :substitute_value_used = 0 |If non-zero, indicates that the variable value is a nominal value used when a measured or calibrated value is not available for a mandatory variable.
 
  |{var}short non_quantitative_processing(ping_time) |M |Settings of any processing that is applied prior to recording backscatter data that may prevent the calculation of calibrated backscatter. A value of 0 always indicates no such processing.
- 2+|{attr}:flag_meanings |Space-separated list of non-quantitative processing setting words or phrases. The first item must always be the no non-quantitative processing setting and subsequent items as appropriate to the sonar and data(e.g. ”no_non_quantitative_processing simrad_noise_filter_weak simrad_noise_filter_medium simrad_noise_filter_strong”).
- 2+|{attr}short :flag_values |List of unique values (e.g. 0, 1, 3, 4) that indicate different non-quantitative processing settings that could be present in the sonar data. Must have the same number of values as settings given in the flag_meanings attribute.
+ 2+|{attr}:flag_meanings = "unknown" |Space-separated list of non-quantitative processing setting words or phrases. The first item must always be the no non-quantitative processing setting and subsequent items as appropriate to the sonar and data(e.g. ”no_non_quantitative_processing simrad_noise_filter_weak simrad_noise_filter_medium simrad_noise_filter_strong”).
+ 2+|{attr}short :flag_values = 0 |List of unique values (e.g. 0, 1, 3, 4) that indicate different non-quantitative processing settings that could be present in the sonar data. Must have the same number of values as settings given in the flag_meanings attribute.
  3+|{attr}:long_name = "Presence or not of non-quantitative processing applied to the backscattering data (sonar specific)" 
  3+|{attr}:coordinates = "ping_time platform_latitude platform_longitude" 
 

--- a/docs/tableGyro_sub_group.adoc
+++ b/docs/tableGyro_sub_group.adoc
@@ -1,0 +1,30 @@
+:var: {nbsp}{nbsp}{nbsp}{nbsp}
+:attr: {var}{var}
+[cols="25%,10%,65%",options="header",]
+|===
+|Description |Obligation |Comment
+s|Group attributes | |
+ |{attr}string :description |O |System description
+ 
+s|Dimensions | |
+ |{var}time | |can be fixed or unlimited length, as appropriate
+ 
+s|Coordinate variables | |
+ |{var}uint64 time(time) |M |Time from gyro sensor
+ 3+|{attr}:axis = "T" 
+ 3+|{attr}:calendar = "gregorian" 
+ 3+|{attr}:long_name = "Timestamps for gyro data" 
+ 3+|{attr}:standard_name = "time" 
+ 3+|{attr}:units = "nanoseconds since 1970-01-01 00:00:00Z" or "nanoseconds since 1601-01-01 00:00:00Z" 
+ 3+|{attr}:coordinates = "time latitude longitude" 
+ 
+s|Variables | |
+ |{var}float heading(time) |MA |Heading refers to the direction a platform is pointing. This may or may not be the direction that the platform actually travels, which is known as its course or track. Any difference between course and heading is due to the motion of the underlying medium, the air or water, or other effects like skidding or slipping. Heading is typically based on compass directions, so 0° (or 360°) indicates a direction toward true North, 90° indicates a direction toward true East, 180° is true South, and 270° is true West.  
+ 3+|{attr}:standard_name = "platform_orientation" 
+ 3+|{attr}:units = "degree" 
+ 3+|{attr}:long_name = "Platform heading(true)" 
+ 3+|{attr}:coordinates = "latitude longitude" 
+  
+s|Subgroups | |
+ |{var}NMEA |O |Suggested subgroup to store raw NMEA data.²
+|===

--- a/docs/tablePlatform.adoc
+++ b/docs/tablePlatform.adoc
@@ -15,6 +15,7 @@ s|Dimensions | |
  |{var}transducer |M |Transducer count
  |{var}position |M |position sensor count
  |{var}MRU |M |MRU attitude sensor count
+ |{var}gyro |M |Gyroscope sensor count
  
 s|Variables | |
  |{var}float MRU_offset_x(MRU) |R |_x_-axis component of the vector from the platform coordinate system origin to the motion reference unit origin.
@@ -47,6 +48,20 @@ s|Variables | |
  |{var}string MRU_ids(MRU) |MA |MRU serial number or identification name. Must be a valid netCDF4 group name.
  
  |{var}string position_ids(position) |MA |Position sensor serial number or identification name. Must be a valid netCDF4 group name.
+ 
+ |{var}string gyro_ids(gyro) |MA |Gyroscope serial number or identification name. Must be a valid netCDF4 group name.
+ 
+ |{var}float gyro_offset_x(gyro) |R |Distance from the platform coordinate system origin to the gyro sensor origin along the _x_-axis.
+ 3+|{attr}:long_name = "Distance from the platform coordinate system origin to the gyro sensor origin  along the _x_-axis." 
+ 3+|{attr}:units = "m" 
+ 
+ |{var}float gyro_offset_y(gyro) |R |Distance from the platform coordinate system origin to the gyro sensor origin along the _y_-axis.
+ 3+|{attr}:long_name = "Distance from the platform coordinate system origin to the gyro sensor origin along the _y_-axis." 
+ 3+|{attr}:units = "m" 
+ 
+ |{var}float gyro_offset_z(gyro) |R |Distance from the platform coordinate system origin to the gyro sensor origin along the _z_-axis.
+ 3+|{attr}:long_name = "Distance from the platform coordinate system origin to the gyro sensor origin along the _z_-axis." 
+ 3+|{attr}:units = "m" 
  
  |{var}float position_offset_x(position) |R |Distance from the platform coordinate system origin to the latitude/longitude position origin along the _x_-axis.
  3+|{attr}:long_name = "Distance along the _x_-axis from the platform coordinate system origin to the latitude/longitude sensor origin" 
@@ -97,6 +112,7 @@ s|Variables | |
  3+|{attr}:units = "m" 
 
 s|Subgroups | |
- |{var}Positions |M |Suggested subgroup to store Position sensor data.
- |{var}Attitudes |M |Suggested subgroup to store MRU sensor data.
+ |{var}Position |M |Suggested subgroup to store Position sensor data.
+ |{var}Attitude |M |Suggested subgroup to store MRU sensor data.
+ |{var}Gyro |M |Suggested subgroup to store gyroscope sensor data.
 |===


### PR DESCRIPTION
In the last quarter of 2024, Kongsberg made several evolutions in the EK80 software in order to be compliant to the SONAR-netCDF4 2.0 format.
During tests some minor evolutions where required to take into account for all cases, this merge request contains those changes : 

-Add gyro sensor attributes to consider the cases where heading is given by a gyroscope, it was not possible to add those into Attitude or Position subgroup where more variables where expected and mandatory

-Remove duplicate variable calibrated_frequency, frequency variable has exactly the same meaning

- Minor :  set default value for flag_meanings and flag_values  in BeamGroup1 dans BeamGridGroup1
   